### PR TITLE
Fix camera detection (v2) on macOS 26.3

### DIFF
--- a/Lolgato/CameraUsageDetector.swift
+++ b/Lolgato/CameraUsageDetector.swift
@@ -25,13 +25,34 @@ class CameraUsageDetector {
 
         if enabled {
             logger.info("Starting camera polling")
-            startMonitoring(interval: interval)
+            ensureCameraAccess { [weak self] granted in
+                guard let self, granted, self.isMonitoringEnabled else {
+                    self?.logger.warning("Camera access not granted, cannot monitor camera usage")
+                    return
+                }
+                self.startMonitoring(interval: interval)
+            }
         } else {
             logger.info("Stopping camera polling")
             stopMonitoring()
         }
     }
 
+    private func ensureCameraAccess(completion: @escaping (Bool) -> Void) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            DispatchQueue.main.async { completion(true) }
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    completion(granted)
+                }
+            }
+        default:
+            DispatchQueue.main.async { completion(false) }
+        }
+    }
+    
     private func startMonitoring(interval: TimeInterval) {
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             self?.checkCameraStatus()


### PR DESCRIPTION
## Summary
- macOS 26.3 now requires camera TCC (Transparency, Consent, and Control) authorization to query `kCMIODevicePropertyDeviceIsRunningSomewhere` via CoreMediaIO
- Without permission, the property silently returns `0` for all devices, making "Lights on Camera" unable to detect active cameras
- Added `ensureCameraAccess()` that checks/requests camera authorization before starting the polling timer

## Test plan
- [ ] Enable "Lights on Camera" — should see a macOS camera permission prompt on first use
- [ ] Grant permission, start a video call or open Photo Booth — lights should turn on
- [ ] Deny permission — feature gracefully stays disabled with a log warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)