### PR TITLE
Start camera polling at launch when lightsOnWithCamera is already enabled

### DIFF
--- a/Lolgato/AppCoordinator.swift
+++ b/Lolgato/AppCoordinator.swift
@@ -90,6 +90,11 @@ class AppCoordinator: ObservableObject {
     }
 
     private func setupBindings() {
+        // Apply persisted state immediately. objectWillChange only fires on
+        // user-driven changes, so without this the detector never starts when
+        // lightsOnWithCamera is already true at launch (issue #7).
+        cameraDetector.updateMonitoring(enabled: appState.lightsOnWithCamera)
+
         appState.objectWillChange
             .sink { [weak self] _ in
                 guard let self else { return }


### PR DESCRIPTION
## Summary

Fixes #7. The `CameraUsageDetector` polling timer was never starting at app launch when `lightsOnWithCamera` was already enabled from a prior session, so the light never reacted to camera activity until the user manually toggled the setting off and on.

## Root cause

`updateMonitoring(enabled:)` is only invoked from `appState.objectWillChange.sink { ... }` in `AppCoordinator.setupBindings()`. That publisher fires on user-driven setting changes — not on app launch. With `lightsOnWithCamera = true` already persisted, the detector is constructed but its polling timer never starts.

This is independent of, and complementary to, the previous v2 fix (0c7927b) that added camera TCC authorization: that fix only takes effect when `updateMonitoring(enabled: true)` is actually called.

## Reproduction (without this patch)

1. Enable "Lights on with Camera" and quit the app
2. Relaunch the app
3. Open Photo Booth (or any video app)
4. Light does not turn on
5. Lolgato's logs show `CameraMonitor initialized` but never `Starting camera polling`
6. Toggle the setting off and back on — now `Starting camera polling` fires and the feature works for the rest of the session

## Fix

Apply the persisted state once during binding setup so the detector starts polling immediately on launch.

## Verification

Built locally on macOS 26.5 with this patch. On launch (no setting toggle), logs now show `Starting camera polling` and Photo Booth correctly triggers `Checked and turned on necessary lights due to camera activity`.